### PR TITLE
OM-923 add bundle version and update target

### DIFF
--- a/FootlessParser.xcodeproj/FootlessParser_Info.plist
+++ b/FootlessParser.xcodeproj/FootlessParser_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>186</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>

--- a/FootlessParser.xcodeproj/project.pbxproj
+++ b/FootlessParser.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				USE_HEADERMAP = NO;
+				VALID_ARCHS = "i386 x86_64 arm64 armv7 armv7s";
 			};
 			name = Debug;
 		};
@@ -339,6 +340,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 3.0;
 				USE_HEADERMAP = NO;
+				VALID_ARCHS = "i386 x86_64 arm64 armv7 armv7s";
 			};
 			name = Release;
 		};

--- a/FootlessParser.xcodeproj/project.pbxproj
+++ b/FootlessParser.xcodeproj/project.pbxproj
@@ -261,7 +261,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_NS_ASSERTIONS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -285,7 +285,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;
@@ -306,7 +306,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;
@@ -324,7 +324,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_OPTIMIZATION_LEVEL = s;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/FootlessParser.xcodeproj/project.pbxproj
+++ b/FootlessParser.xcodeproj/project.pbxproj
@@ -116,7 +116,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -124,7 +124,6 @@
 				OBJ_16 /* Tests */,
 				OBJ_27 /* Products */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -201,7 +200,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_27 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -286,6 +285,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;
@@ -306,6 +306,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;

--- a/FootlessParser.xcodeproj/project.pbxproj
+++ b/FootlessParser.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.13;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -291,6 +292,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx10.13;
 				TARGET_NAME = FootlessParser;
 			};
 			name = Debug;
@@ -305,6 +307,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.13;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,6 +315,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx10.13;
 				TARGET_NAME = FootlessParser;
 			};
 			name = Release;

--- a/FootlessParser.xcodeproj/project.pbxproj
+++ b/FootlessParser.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.13;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -307,7 +307,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = FootlessParser.xcodeproj/FootlessParser_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.13;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = "$(inherited)";

--- a/FootlessParser.xcodeproj/project.pbxproj
+++ b/FootlessParser.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				TARGET_NAME = FootlessParser;
+				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
 			};
 			name = Debug;
 		};
@@ -317,6 +318,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				TARGET_NAME = FootlessParser;
+				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
 			};
 			name = Release;
 		};

--- a/FootlessParser.xcodeproj/project.pbxproj
+++ b/FootlessParser.xcodeproj/project.pbxproj
@@ -292,7 +292,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = macosx10.13;
+				SDKROOT = iphoneos;
 				TARGET_NAME = FootlessParser;
 			};
 			name = Debug;
@@ -315,7 +315,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = FootlessParser;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = macosx10.13;
+				SDKROOT = iphoneos;
 				TARGET_NAME = FootlessParser;
 			};
 			name = Release;


### PR DESCRIPTION
#### What are the relevant tickets?
https://workwithopal.atlassian.net/browse/OM-923

#### Goal of the PR:
Add an explicit CFBundleVersion because it wasn't being calculated before.  Also, give an explicit OS target.

#### Background context to the change:
Need to ship the app to the app store and the missing CFBundleVersion was causing it to not pass review.

#### Migrations and deployment instructions:
Nothing to test, only dependency changes

#### Developer:
- [ ] Add tests for new functionality
- [ ] Make tickets to update applications that depend on OpalKit
- [ ] Update README
- [ ] Update CHANGELOG

#### Reviewer 
- [ ] Review code changes
- [ ] Run tests
